### PR TITLE
Fix missing Excel writer dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.32.3
 streamlit==1.39.0
 rich<14,>=10.14.0
 webdriver-manager==4.0.1
+openpyxl==3.1.5


### PR DESCRIPTION
## Summary
- add openpyxl requirement for Excel output

## Testing
- `python -m py_compile 'IncorporaAI 4.0.py' app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f50a0dfac83259e37a6c985636c29